### PR TITLE
More fixes

### DIFF
--- a/spirv_tools/read_spirv.py
+++ b/spirv_tools/read_spirv.py
@@ -202,6 +202,20 @@ def parse_operand(binary, module, kind):
             operands.append(word)
             tmp_id = parse_id(binary, module)
             operands.append(tmp_id)
+    elif kind == 'OptionalMemoryAccessMask':
+        val = binary.get_next_word(accept_eol=True)
+        if val is None:
+            return []
+        result = expand_mask(kind[8:], val)
+        try:
+            aligned_idx = result.index('Aligned')
+        except ValueError:
+            pass
+        else:
+            result[aligned_idx] = (
+                    'Aligned', binary.get_next_word(accept_eol=False))
+        return [result]
+
     elif kind[:8] == 'Optional' and kind[-4:] == 'Mask':
         val = binary.get_next_word(accept_eol=True)
         if val is None:

--- a/spirv_tools/write_il.py
+++ b/spirv_tools/write_il.py
@@ -86,7 +86,7 @@ def output_instruction(stream, module, inst, is_raw_mode, indent='  '):
     kind = None
     if inst.operands:
         line = line + ' '
-        operand_kind = zip(inst.operands, op_format['operands'])
+        operand_kind = list(zip(inst.operands, op_format['operands']))
         while operand_kind:
             operand, kind = operand_kind[0]
             if kind == 'Id' or kind == 'OptionalId':

--- a/spirv_tools/write_il.py
+++ b/spirv_tools/write_il.py
@@ -310,7 +310,7 @@ def format_type_name(module, inst):
         if width not in [8, 16, 32, 64]:
             raise ir.IRError("Invalid OpTypeInt width " + str(width))
         signedness = inst.operands[1]
-        if not signedness in [0, 1]:
+        if signedness not in [0, 1]:
             error = "Invalid OpTypeInt signedness " + str(signedness)
             raise ir.IRError(error)
         type_name = 's' if signedness else 'u'

--- a/spirv_tools/write_il.py
+++ b/spirv_tools/write_il.py
@@ -21,7 +21,14 @@ def format_mask(kind, mask_list):
     if not mask_list:
         return [val for val in spirv.spv[kind] if spirv.spv[kind][val] == 0][0]
     separator = ' | '
-    return separator.join(mask_list)
+
+    def stringify_mask_entry(e):
+        if isinstance(e, tuple):
+            return "%s(%s)" % (e[0], ", ".join(str(i) for i in e[1:]))
+        else:
+            return e
+
+    return separator.join(stringify_mask_entry(e) for e in mask_list)
 
 
 def output_extinst_instruction(stream, module, inst, is_raw_mode, indent='  '):


### PR DESCRIPTION
Here are some more changes. Let me know if you'd like those split up or changed. The most important one is a fix for the inability to load/represent [Aligned](https://www.khronos.org/registry/spir-v/specs/1.1/SPIRV.html#_a_id_memory_access_a_memory_access) (which takes an extra operand). Here's a [module](https://tiker.net/tmp/add-vectors.spv) that exercises this. One potential issue is that this only fixes the load-SPIRV and write-IL bits of this, but it leaves the write-SPIRV and load-IL bits out.

FWIW, I'm interested in SPIRV generally and your code specifically from the OpenCL perspective as a target for https://github.com/inducer/loopy.
